### PR TITLE
Enable overriding of element search

### DIFF
--- a/src/main/groovy/org/xpur/XmlIterator.groovy
+++ b/src/main/groovy/org/xpur/XmlIterator.groovy
@@ -55,7 +55,7 @@ class XmlIterator implements Iterator {
      *  2. String - if the element is a simple tag, e.g. <name>John</name>
      *
      * @param inputStream source
-     * @param elementName name of child element to find
+     * @param elementName name of child element to find or null if all elements are to be returned
      */
     XmlIterator(InputStream inputStream, String elementName) {
         this.reader = XMLInputFactory.newInstance().createXMLEventReader(inputStream)
@@ -70,7 +70,7 @@ class XmlIterator implements Iterator {
      *  2. String - if the element is a simple tag, e.g. <name>John</name>
      *
      * @param reader source
-     * @param elementName name of child element to find
+     * @param elementName name of child element to find or null if all elements are to be returned
      */
     XmlIterator(Reader reader, String elementName) {
         this.reader = XMLInputFactory.newInstance().createXMLEventReader(reader)
@@ -80,7 +80,7 @@ class XmlIterator implements Iterator {
     @Override
     boolean hasNext() {
         if (currentElement == null && reader.hasNext())
-            currentElement = findNext(elementName)
+            currentElement = findNext()
 
         return currentElement != null
     }
@@ -99,12 +99,24 @@ class XmlIterator implements Iterator {
         return result
     }
 
-    private Object findNext(String elementName) {
+    /**
+     * This method decides whether an element is to be returned by the iterator.
+     * The base implementation matches a specified elementName, though subclasses
+     * may redefine this element search.
+     *
+     * @param startElement element
+     * @return true iff an element is to be returned by the iterator
+     */
+    protected boolean isDesired(StartElement startElement) {
+        elementName == null || startElement.name?.localPart == elementName
+    }
+
+    private Object findNext() {
         while (reader.hasNext()) {
             XMLEvent event = reader.nextEvent()
             if (event.isStartElement()) {
                 StartElement startElement = event.asStartElement()
-                if (startElement.name?.localPart == elementName) {
+                if (isDesired(startElement)) {
                     return create(startElement)
                 }
             }

--- a/src/test/groovy/org/xpur/XmlIteratorTest.groovy
+++ b/src/test/groovy/org/xpur/XmlIteratorTest.groovy
@@ -1,7 +1,7 @@
 package org.xpur
 
 import spock.lang.Specification
-
+import javax.xml.stream.events.StartElement
 import static java.nio.charset.StandardCharsets.UTF_8
 
 class XmlIteratorTest extends Specification {
@@ -180,4 +180,32 @@ class XmlIteratorTest extends Specification {
         car.images.image == ["test1", "test2", "test3"]
     }
 
+    def "handle undefined element name"() {
+        def resource = getClass().getResourceAsStream("people.xml")
+
+        when: "iterating elements without tag name specified"
+        def result = new XmlIterator(resource, null).collect { it }
+
+        then: "single element with sub-lists is returned"
+        result == [
+            [
+                adult: ['Jack', 'Jane', 'John'],
+                child: 'Jim'
+            ]
+        ]
+    }
+
+    def "refine element matching"() {
+        def resource = getClass().getResourceAsStream("people.xml")
+
+        when: "overriding matching predicate"
+        def result = new XmlIterator(resource, null) {
+            protected boolean isDesired(StartElement startElement) {
+                startElement.name.localPart in ['adult', 'child']
+            }
+        }.collect { it }
+
+        then: "all matching elements are returned"
+        result == ['Jack', 'Jane', 'Jim', 'John']
+    }
 }

--- a/src/test/resources/org/xpur/people.xml
+++ b/src/test/resources/org/xpur/people.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<people>
+    <adult>Jack</adult>
+    <adult>Jane</adult>
+    <child>Jim</child>
+    <adult>John</adult>
+</people>


### PR DESCRIPTION
Allow for more flexibility with regards to what XML elements are to be returned by the iterator than just an element name match.
1. If `elementName` is null, return all
2. Provide a protected predicate for subclasses